### PR TITLE
Add option to change the name of the __object__ directory

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -165,7 +165,7 @@ function getOpts(extaOpts) {
     .option('-d --data-dir <dirs>', "Directory of data files with sub directories '/Sound files' (for .wav) and '/Transcripts' (.csv)")
     .option('-D --debug <ns>', 'Use this in your collector to turn off some behaviour for debugging')
     .option('-m --multiple', 'Output multiple Objects rather than a single object')
-    .option('-d --object-dir <ns>', 'Name for the folder containing object metadata, default "__object__"')
+    .option('-O --object-dir <ns>', 'Name for the folder containing object metadata, default "__object__"')
 
   program.parse(process.argv);
   return program.opts();

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -39,7 +39,6 @@ class CollectionObject {
     const rocrateOpts = {alwaysAsArray: true, resolveLinks: true};
     if (crateDir) {
       // Load the RO-Crate from the specified directory
-      console.log("CRATE DIR", crateDir)
       const metaPath = path.join(crateDir, "ro-crate-metadata.json");
       const json = JSON.parse(fs.readFileSync(metaPath));
       this.crate = new ROCrate(json, rocrateOpts);
@@ -166,6 +165,7 @@ function getOpts(extaOpts) {
     .option('-d --data-dir <dirs>', "Directory of data files with sub directories '/Sound files' (for .wav) and '/Transcripts' (.csv)")
     .option('-D --debug <ns>', 'Use this in your collector to turn off some behaviour for debugging')
     .option('-m --multiple', 'Output multiple Objects rather than a single object')
+    .option('-d --object-dir <ns>', 'Name for the folder containing object metadata, default "__object__"')
 
   program.parse(process.argv);
   return program.opts();
@@ -188,6 +188,7 @@ class Collector {
     this.repoPath = this.opts.repoPath || "../repo";
     this.repoScratch = this.opts.repoScratch || "../scratch";
     this.repoName = this.opts.repoName || "repository";
+    this.objectDirName = this.opts.objectDir || "__object__";
     this.debug = this.opts.debug;
     if (this.debug == "true") { // Force type coercion
       this.debug = true;
@@ -206,7 +207,8 @@ class Collector {
 
   async connect() {
     this.repo = ocfl.storage({root: this.repoPath, layout: {
-        extensionName: '000N-path-direct-storage-layout'
+        extensionName: '000N-path-direct-storage-layout',
+        suffix: `/${this.objectDirName}`,
       }});
 
     if (!await fs.pathExists(this.repoPath)) {


### PR DESCRIPTION
Adds a new option to allow the name of the metadata sub-directory to be changed via command line options.