### PR TITLE
Added option for addToRepo to copy files

### DIFF
--- a/lib/collector.js
+++ b/lib/collector.js
@@ -130,7 +130,7 @@ class CollectionObject {
 
   /** Adds item to repo
    * */
-  async addToRepo(files = false, fileList) {
+  async addToRepo(files = false, fileList = [[this.dir,""]]) {
     // Write the object into the actual OCFL repo
     //fileList is an array of tuples ([[source,destination],[source,destination]]), files is boolean.
     //if files is true then files in the file list will be included in the object import. This allows files to be 

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -130,9 +130,12 @@ class CollectionObject {
 
   /** Adds item to repo
    * */
-  async addToRepo() {
+  async addToRepo(files = false, fileList) {
     // Write the object into the actual OCFL repo
-    this.crate.addIdentifier({name: this.collector.repoName, identifier: this.id});
+    //fileList is an array of tuples ([[source,destination],[source,destination]]), files is boolean.
+    //if files is true then files in the file list will be included in the object import. This allows files to be 
+    //re-copied only when they've been updated rather than using addFile
+    this.crate.addIdentifier({ name: this.collector.repoName, identifier: this.id });
     const localId = `_:local-id:${this.collector.repoName}:${this.id}`;
     const localRepoId = this.crate.getItem(localId);
     assert(localRepoId, 'Was not able to add identifier');
@@ -142,11 +145,14 @@ class CollectionObject {
     await fs.writeFileSync(rocrateFile, JSON.stringify(this.crate, null, 2));
     await this.generateHTML(rocrateFile);
     let object = this.collector.repo.object(this.id);
-    
-    await object.import(this.dir);
+    let imports = [[this.dir, ""]]
+    if (files) {
+      imports.push(...fileList);
+    }
+    await object.import(imports);
     console.log(`Wrote crate ${object}`);
     console.log(`Deleting crateDir: ${this.dir}`);
-    fs.rmSync(this.dir, {recursive: true, force: true});
+    fs.rmSync(this.dir, { recursive: true, force: true });
     console.log(
       "Deleted"
     )

--- a/lib/collector.js
+++ b/lib/collector.js
@@ -130,7 +130,7 @@ class CollectionObject {
 
   /** Adds item to repo
    * */
-  async addToRepo(files = false, fileList = [[this.dir,""]]) {
+  async addToRepo(files = false, fileList = []) {
     // Write the object into the actual OCFL repo
     //fileList is an array of tuples ([[source,destination],[source,destination]]), files is boolean.
     //if files is true then files in the file list will be included in the object import. This allows files to be 
@@ -146,7 +146,7 @@ class CollectionObject {
     await this.generateHTML(rocrateFile);
     let object = this.collector.repo.object(this.id);
     let imports = [[this.dir, ""]]
-    if (files) {
+    if (files && fileList.length>0) {
       imports.push(...fileList);
     }
     await object.import(imports);


### PR DESCRIPTION
Add the option to specify that there is a list of file paths to be copied as part of the addToRepo import process.